### PR TITLE
feature: update the way BUMP is rendered and show length of data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { MerkleTreeView } from "./MerkleTreeView.tsx";
 import { MerkleTreeProvider } from "./MerkleTreeProvider.tsx";
 import { MerkleTreeSizeSelector } from "./MerkleTreeSizeSelector.tsx";
 import { MerkleProofProvider } from "./MerkleProofsProvider.tsx";
-import { MerkleProofsView } from "./MerkleProofsView.tsx";
 import { ResetProvider } from "./useReset.tsx";
 import { TscMerkleProofsView } from "./TscMerkleProofsView.tsx";
 import { BsvUnifiedMerklePathView } from "./BsvUnifiedMerklePathView.tsx";
@@ -20,10 +19,6 @@ function App() {
             <Grid item xs={12} sx={{ overflow: "auto" }}>
               <MerkleTreeView />
             </Grid>
-            <Grid item xs={12}>
-              <MerkleProofsView />
-            </Grid>
-
             <Grid item xs={12}>
               <BsvUnifiedMerklePathView />
             </Grid>

--- a/src/RenderHashes.tsx
+++ b/src/RenderHashes.tsx
@@ -1,0 +1,3 @@
+export function displayAsIfItWereA32ByteHash(str: string) {
+    return str.repeat(64 / str.length);
+}

--- a/src/TscMerkleProofsView.css
+++ b/src/TscMerkleProofsView.css
@@ -1,5 +1,9 @@
 .tsc-merkle-proofs {
   display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  justify-content: flex-start;
+  align-items: flex-start;
 }
 
 .tsc-merkle-proofs pre {

--- a/src/TscMerkleProofsView.tsx
+++ b/src/TscMerkleProofsView.tsx
@@ -4,19 +4,24 @@ import { useMerklePath } from "./MerkleProofsProvider.tsx";
 import { MerkleProofByTx } from "./merkle-tree-data";
 import * as _ from "lodash";
 import { NoTransactionSelected } from "./NoTransactionSelected.tsx";
+import { displayAsIfItWereA32ByteHash } from "./RenderHashes.tsx";
+
+function mapToTSCFormat(proof: MerkleProofByTx) {
+  return Object.entries(proof)
+    .map((it) => ({
+      index: it[1].index,
+      txOrId: displayAsIfItWereA32ByteHash(it[0]),
+      targetType: "header",
+      target: "000000000000000002bcc1bbe47c4def6a9c1440e9c1b2200fc6a650a0552904",
+      nodes: it[1].path,
+    }))
+    .map((it) => ({ ...it, nodes: it.nodes.map((n) => displayAsIfItWereA32ByteHash(n.hash)) }))
+}
 
 const TscMerkleProofList: FC<{ proof: MerkleProofByTx }> = ({ proof }) => {
   return (
     <div className="tsc-merkle-proofs">
-      {Object.entries(proof)
-        .map((it) => ({
-          index: it[1].index,
-          txOrId: it[0],
-          targetType: "header",
-          target: "00aHEADER_HASH_IS_HERE",
-          nodes: it[1].path,
-        }))
-        .map((it) => ({ ...it, nodes: it.nodes.map((n) => n.hash) }))
+      {mapToTSCFormat(proof)
         .map((it) => (
           <TscMerkleProof key={it.txOrId} proof={it} />
         ))}
@@ -36,17 +41,24 @@ const TscMerkleProof: FC<{ proof: TscMerkleProofFormat }> = ({ proof }) => {
   return <pre>{JSON.stringify(proof, null, 2)}</pre>;
 };
 
+function calculateTheByteLengthOfTSC(proof: MerkleProofByTx) {
+  if (_.isEmpty(proof)) return 0;
+  return Math.ceil(JSON.stringify(mapToTSCFormat(proof)).length / 2);
+}
+
 export const TscMerkleProofsView = () => {
   const { proof } = useMerklePath();
 
   return (
-    <div className="tsc-merkle-proofs-view">
-      <header>TSC format of Merkle Proofs [DEPRECATED]:</header>
-      {_.isEmpty(proof) ? (
-        <NoTransactionSelected />
-      ) : (
-        <TscMerkleProofList proof={proof} />
-      )}
+    <div>
+      <header>TSC Format Merkle Proofs [DEPRECATED]: {calculateTheByteLengthOfTSC(proof)} bytes</header>
+      <div className="tsc-merkle-proofs-view">
+        {_.isEmpty(proof) ? (
+          <NoTransactionSelected />
+        ) : (
+          <TscMerkleProofList proof={proof} />
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/showcase-merkle-path/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/showcase-merkle-path/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

## PR Title as Conventional Commit

## Feature

1. BUMP is now rendered in such a way that it looks smaller - showing how compact the data is. 
2. TSC format is rendered in a flex grid rather than row, to show how much bigger this gets. 
3. Length of both data formats is displayed to show the difference.